### PR TITLE
Fix compilation due to missing include

### DIFF
--- a/src/libpisp/backend/backend_prepare.cpp
+++ b/src/libpisp/backend/backend_prepare.cpp
@@ -7,6 +7,7 @@
  */
 #include "backend.hpp"
 
+#include <cmath>
 #include <string>
 
 #include "common/logging.hpp"


### PR DESCRIPTION
Fix:

backend_prepare.cpp:644:87: error: ‘ceil’ is not a member of ‘std’

by including cmath.