### PR TITLE
backend: Fix compiler error due missing include

### DIFF
--- a/src/libpisp/backend/tiling/rescale_stage.hpp
+++ b/src/libpisp/backend/tiling/rescale_stage.hpp
@@ -8,6 +8,8 @@
 
 #include "stages.hpp"
 
+#include <cstdint>
+
 namespace tiling
 {
 

--- a/src/libpisp/backend/tiling/stages.cpp
+++ b/src/libpisp/backend/tiling/stages.cpp
@@ -2,6 +2,8 @@
 
 #include "pipeline.hpp"
 
+#include <cstdint>
+
 using namespace tiling;
 
 Stage::Stage(char const *name, Pipeline *pipeline, int struct_offset)


### PR DESCRIPTION
Include <cstdint> to fix compiler errors
backend/tiling/stages.cpp:68:46: error: ‘uint8_t’ was not declared in this scope backend/tiling/rescale_stage.hpp:25:57: error: ‘uint8_t’ has not been declared

fixes https://github.com/raspberrypi/libcamera-pi5/issues/36