### PR TITLE
meson: Reduce minimum version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libpisp', 'c', 'cpp',
-        meson_version : '>= 0.64.0',
+        meson_version : '>= 0.56.0',
         version : '0.0.1',
         default_options : [
             'werror=true',


### PR DESCRIPTION
The lowest meson version valid for the project is 0.56 for the project_source_root functionality.

Reduce the minimum required meson version to this to support building on the widest range of distributions.