### PR TITLE
build: Add example libpisp.wrap file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ sudo meson install -C <build_dir>
 ```
 
 ## Linking libpisp with an application
-libpisp can be built and linked as a [meson subproject](https://mesonbuild.com/Subprojects.html) with the following dependency declaration in the target project:
+libpisp can be built and linked as a [meson subproject](https://mesonbuild.com/Subprojects.html) by using an approprite [libpisp.wrap](utils/libpisp.wrap) file and with the following dependency declaration in the target project:
 ```meson
 libpisp_dep = dependency('libpisp', fallback : ['libpisp', 'libpisp_dep'])
 ```
-Alternatively [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) can be used to locate ``libpisp.so`` installed in on of the system directories for other build environments.
+
+Alternatively [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) can be used to locate ``libpisp.so`` installed in of the system directories for other build environments.
 
 ## License
 Copyright © 2023, Raspberry Pi Ltd. Released under the BSD-2-Clause License.

--- a/utils/libpisp.wrap
+++ b/utils/libpisp.wrap
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: CC0-1.0
+
+[wrap-git]
+url = https://github.com/raspberrypi/libpisp.git
+revision = v1.0.0
+depth = 1


### PR DESCRIPTION
Update the link instructions in the documentation to point to this file.