### PR TITLE
Set correct library version, and thus correct automatic soname

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -47,7 +47,7 @@ pisp_sources += version_cpp
 libpisp = library(
     meson.project_name(),
     pisp_sources,
-    soversion : meson.project_version(),
+    version : meson.project_version(),
     include_directories : include_directories(inc_dirs),
     name_prefix : '',
     install : true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -44,14 +44,10 @@ version_cpp = vcs_tag(command : version_cmd,
 
 pisp_sources += version_cpp
 
-# Label the .so with x.y versioning from the project.
-v = meson.project_version().split('.')
-soversion = v[0] + '.' + v[1]
-
 libpisp = library(
     meson.project_name(),
     pisp_sources,
-    soversion : soversion,
+    soversion : meson.project_version(),
     include_directories : include_directories(inc_dirs),
     name_prefix : '',
     install : true,


### PR DESCRIPTION
From https://mesonbuild.com/Reference-manual_functions.html:
 If soversion is not specified, the first part of version is used
 instead (see below). For example, if version is 3.6.0 and soversion
 is not defined, it is set to 3.

With this change, correct libpispi.so.1 symlink to libpispi.so.1.0.1
is produced, as expected by most distributions.

Fixes: 2c8b00e7e3 ("build: Update .so versioning to x.y format")