### PR TITLE
backend: Fix compiler error by missing cstdint include

### DIFF
--- a/src/libpisp/backend/tiling/pipeline.cpp
+++ b/src/libpisp/backend/tiling/pipeline.cpp
@@ -12,6 +12,8 @@
 #include "output_stage.hpp"
 #include "stages.hpp"
 
+#include <cstdint>
+
 using namespace tiling;
 
 Pipeline::Pipeline(char const *name, Config const &config) : name_(name), config_(config)


### PR DESCRIPTION
Hi! I met similar compile error of https://github.com/raspberrypi/libpisp/pull/5 such as following.

```
$ meson compile -C build
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/bin/ninja -C /tmp/ww/libpisp/build
ninja: Entering directory `/tmp/ww/libpisp/build'
[3/4] Compiling C++ object src/libpisp.so.1.0.3.p/libpisp_backend_tiling_pipeline.cpp.o
FAILED: src/libpisp.so.1.0.3.p/libpisp_backend_tiling_pipeline.cpp.o
c++ -Isrc/libpisp.so.1.0.3.p -Isrc -I../src -Isrc/libpisp -I../src/libpisp -I../subprojects/nlohmann_json-3.11.2/single_include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c++17 -O3 -DPISP_LOGGING_ENABLE=0 -fPIC -pthread -MD -MQ src/libpisp.so.1.0.3.p/libpisp_backend_tiling_pipeline.cpp.o -MF src/libpisp.so.1.0.3.p/libpisp_backend_tiling_pipeline.cpp.o.d -o src/libpisp.so.1.0.3.p/libpisp_backend_tiling_pipeline.cpp.o -c ../src/libpisp/backend/tiling/pipeline.cpp
../src/libpisp/backend/tiling/pipeline.cpp: In member function ‘void tiling::Pipeline::Tile(void*, size_t, size_t, tiling::Length2*)’:
../src/libpisp/backend/tiling/pipeline.cpp:51:32: error: ‘uint8_t’ was not declared in this scope
   51 |                 void *y_src = (uint8_t *)mem + item_size * grid->dx * j;
      |                                ^~~~~~~
../src/libpisp/backend/tiling/pipeline.cpp:13:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   12 | #include "output_stage.hpp"
  +++ |+#include <cstdint>
   13 | #include "stages.hpp"
../src/libpisp/backend/tiling/pipeline.cpp:51:41: error: expected primary-expression before ‘)’ token
   51 |                 void *y_src = (uint8_t *)mem + item_size * grid->dx * j;
      |                                         ^
../src/libpisp/backend/tiling/pipeline.cpp:54:49: error: expected primary-expression before ‘)’ token
   54 |                         void *x_src = (uint8_t *)mem + item_size * i;
      |                                                 ^
../src/libpisp/backend/tiling/pipeline.cpp:55:48: error: expected primary-expression before ‘)’ token
   55 |                         void *dest = (uint8_t *)y_src + item_size * i;
      |                                                ^
../src/libpisp/backend/tiling/pipeline.cpp: In member function ‘int tiling::Pipeline::tileDirection(tiling::Dir, void*, size_t, size_t)’:
../src/libpisp/backend/tiling/pipeline.cpp:86:31: error: ‘uint8_t’ was not declared in this scope
   86 |                 void *dest = (uint8_t *)mem + num_tiles * item_size;
      |                               ^~~~~~~
../src/libpisp/backend/tiling/pipeline.cpp:86:31: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
../src/libpisp/backend/tiling/pipeline.cpp:86:40: error: expected primary-expression before ‘)’ token
   86 |                 void *dest = (uint8_t *)mem + num_tiles * item_size;
      |                                        ^
../src/libpisp/backend/tiling/pipeline.cpp:68:44: error: unused parameter ‘mem’ [-Werror=unused-parameter]
   68 | int Pipeline::tileDirection(Dir dir, void *mem, size_t num_items, size_t item_size)
      |                                      ~~~~~~^~~
../src/libpisp/backend/tiling/pipeline.cpp:68:74: error: unused parameter ‘item_size’ [-Werror=unused-parameter]
   68 | int Pipeline::tileDirection(Dir dir, void *mem, size_t num_items, size_t item_size)
      |                                                                   ~~~~~~~^~~~~~~~~
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```

To fix this error, I added `#include <cstdint>` to `src/libpisp/backend/tiling/pipeline.cpp` and then it seems that it works correctly.
Could you merge this PR ?