### PR TITLE
backend: Fix for missing _DYNAMIC declaration in musl libc

### DIFF
--- a/src/libpisp/backend/backend_default_config.cpp
+++ b/src/libpisp/backend/backend_default_config.cpp
@@ -20,6 +20,10 @@
 #include "common/pisp_pwl.hpp"
 #include "pisp_be_config.h"
 
+// musl doesn't declare _DYNAMIC in link.h, declare it manually, see:
+// https://github.com/raspberrypi/libpisp/issues/25
+extern ElfW(Dyn) _DYNAMIC[];
+
 using json = nlohmann::json;
 
 // Where it might be helpful we initialise some blocks with the "obvious" default parameters. This saves users the trouble,


### PR DESCRIPTION
The _DYNAMIC symbol is not declared in musl link.h causing a build error. Decalare it manually to fix this.