### PR TITLE
libpisp: include <string> explicitly

### DIFF
--- a/src/libpisp/common/pisp_utils.cpp
+++ b/src/libpisp/common/pisp_utils.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <map>
+#include <string>
 
 #include "backend/pisp_be_config.h"
 


### PR DESCRIPTION
The pisp_utils references std::string without directly pulling in the <string> header.

Bring in the include explicitly to prevent compiler warnings.

This fixes compile issues I had while trying to build this in a bookworm container with GCC-12.
I'm surprised this came up, but perhaps it was something about the minimal configuration of the container.

Fixes:

```
[4/25] Compiling C++ object src/libpisp.so.1.1.0.p/libpisp_common_pisp_utils.cpp.o
FAILED: src/libpisp.so.1.1.0.p/libpisp_common_pisp_utils.cpp.o 
c++ -Isrc/libpisp.so.1.1.0.p -Isrc -I../src -Isrc/libpisp -I../src/libpisp -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c++17 -O3 -DPISP_LOGGING_ENABLE=0 -Wno-address-of-packed-member -fPIC -pthread -MD -MQ src/libpisp.so.1.1.0.p/libpisp_common_pisp_utils.cpp.o -MF src/libpisp.so.1.1.0.p/libpisp_common_pisp_utils.cpp.o.d -o src/libpisp.so.1.1.0.p/libpisp_common_pisp_utils.cpp.o -c ../src/libpisp/common/pisp_utils.cpp
../src/libpisp/common/pisp_utils.cpp:214:28: error: ‘string’ is not a member of ‘std’
  214 | static const std::map<std::string, uint32_t> &formats_table()
      |                            ^~~~~~
../src/libpisp/common/pisp_utils.cpp:16:1: note: ‘std::string’ is defined in header ‘<string>’; did you forget to ‘#include <string>’?
   15 | #include "logging.hpp"
  +++ |+#include <string>
   16 | 

```