### PR TITLE
utils: Preserve API by overloading libpisp::compute_optimal_stride

### DIFF
--- a/src/libpisp/common/pisp_utils.cpp
+++ b/src/libpisp/common/pisp_utils.cpp
@@ -118,6 +118,11 @@ void compute_optimal_stride(pisp_image_format_config &config, bool preserve_subs
 	compute_stride_align(config, PISP_BACK_END_OUTPUT_MAX_ALIGN, preserve_subsample_ratio);
 }
 
+void compute_optimal_stride(pisp_image_format_config &config)
+{
+	compute_optimal_stride(config, false);
+}
+
 void compute_addr_offset(const pisp_image_format_config &config, int x, int y, uint32_t *addr_offset,
 						 uint32_t *addr_offset2)
 {

--- a/src/libpisp/common/utils.hpp
+++ b/src/libpisp/common/utils.hpp
@@ -14,7 +14,8 @@ namespace libpisp
 {
 
 void compute_stride(pisp_image_format_config &config, bool preserve_subsample_ratio = false);
-void compute_optimal_stride(pisp_image_format_config &config, bool preserve_subsample_ratio = false);
+void compute_optimal_stride(pisp_image_format_config &config);
+void compute_optimal_stride(pisp_image_format_config &config, bool preserve_subsample_ratio);
 void compute_stride_align(pisp_image_format_config &config, int align, bool preserve_subsample_ratio = false);
 void compute_addr_offset(const pisp_image_format_config &config, int x, int y, uint32_t *addr_offset,
 						 uint32_t *addr_offset2);


### PR DESCRIPTION
The signature for `libpisp::compute_optimal_stride` has changed, and it is called by libcamera extrenally. While adding a default parameter makes it backwards compatible, using libcamera.so to build rpicam-apps with `-Wl, --no-undefined` will cause undefined symbols.

This change preserves the API by overloading the function to have both the previous and new signature. This will emit both symbols in the shared object. Only `compute_optimal_stride` in `utils.hpp` needs this change as this is the only function being used in libcamera as an API from utils.

More context at https://bugs.launchpad.net/ubuntu/+source/libpisp/+bug/2115319