### PR TITLE
utils: Re-license version.py and libpisp.wrap to BSD-2-Clause

### DIFF
--- a/utils/libpisp.wrap
+++ b/utils/libpisp.wrap
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: CC0-1.0
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (C) 2023, Raspberry Pi Ltd
 
 [wrap-git]

--- a/utils/version.py
+++ b/utils/version.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
 
-# SPDX-License-Identifier: CC0-1.0
-# Copyright (C) 2021, Raspberry Pi Ltd.
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright (C) 2021-2025, Raspberry Pi Ltd.
 #
-# Generate version information for libcamera-apps
+# Generate version information for libpisp
 
 import subprocess
 import sys


### PR DESCRIPTION
As per Creative Commons guidance, source files should not be used for software source files, so re-license these files to use BSD-2-Clause to follow the rest of the source files in this library.

As a drive-by, fix for wrong lib name: s/libcamera-apps/libpisp/