### PR TITLE
helpers: media_device: ignore lockf return value

### DIFF
--- a/src/helpers/media_device.cpp
+++ b/src/helpers/media_device.cpp
@@ -248,6 +248,6 @@ std::map<std::string, DeviceFd>::iterator MediaDevice::unlock(const std::string 
 	if (it == lock_map_.end())
 		return lock_map_.end();
 
-	lockf(it->second.Get(), F_ULOCK, 0);
+	std::ignore = lockf(it->second.Get(), F_ULOCK, 0);
 	return lock_map_.erase(it);
 }


### PR DESCRIPTION
When using gcc (with ~-Werror=unused-result), compilation fails, because the return value of lockf is ignored at one place.

To avoid this error, assign the return value to std::ignore.


The error message:
```
| ../sources/libpisp-1.2.1/src/helpers/media_device.cpp: In member function 'std::map<std::__cxx11::basic_string<char>, libpisp::helpers::DeviceFd>::iterator libpisp::helpers::MediaDevice::unlock(const std::string&)':
| ../sources/libpisp-1.2.1/src/helpers/media_device.cpp:251:14: error: ignoring return value of 'int lockf(int, int, __off64_t)' declared with attribute 'warn_unused_result' [-Werror=unused-result]
|   251 |         lockf(it->second.Get(), F_ULOCK, 0);
|       |         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| cc1plus: all warnings being treated as errors

```