### PR TITLE
build: Simplify the version file generation

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -33,19 +33,8 @@ add_project_arguments(logging_args, language : 'cpp')
 # Needed to avoid (erroneous) warnings on the use of addresses of fields in __attribute__((packed)) structs.
 add_project_arguments('-Wno-address-of-packed-member', language : 'cpp')
 
-meson.add_dist_script(meson.project_source_root() / 'utils' / 'gen-dist.sh')
-
 # Generate a version string:
 version_cmd = [meson.project_source_root() / 'utils' / 'version.py', meson.project_version()]
-
-# Check if a version.gen file is present.
-# This would have been generated from the meson dist command.
-fs = import('fs')
-dist_version_file = meson.project_source_root() / 'version.gen'
-if fs.is_file(dist_version_file)
-    version_cmd += fs.read(dist_version_file)
-endif
-
 version_template = meson.project_source_root() / 'utils' / 'version.cpp.in'
 version_cpp = vcs_tag(command : version_cmd,
                       input : version_template,

--- a/utils/gen-dist.sh
+++ b/utils/gen-dist.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# SPDX-License-Identifier: BSD-2-Clause
-# Copyright (C) 2023, Raspberry Pi Ltd
-
-cd "$MESON_SOURCE_ROOT" || return
-git rev-parse HEAD > "$MESON_DIST_ROOT"/version.gen

--- a/utils/version.py
+++ b/utils/version.py
@@ -38,21 +38,13 @@ def generate_version():
             if r.returncode:
                 commit = commit + '-dirty'
 
-        elif len(sys.argv) == 3:
-            commit = sys.argv[2].lower().strip()
-            if any(c not in hexdigits for c in commit):
-                raise RuntimeError('Invalid git sha!')
-
-            commit = commit[0:digits]
-      
         else:
             raise RuntimeError('Invalid number of command line arguments') 
 
         commit = f'v{sys.argv[1]} {commit}'
 
     except RuntimeError as e:
-        print(f'ERR: {e}', file=sys.stderr)
-        commit = '0' * digits + '-invalid'
+        commit = f'v{sys.argv[1]}'
 
     finally:
         date_str = time.strftime(


### PR DESCRIPTION
Remove the gen-dist.sh script and do not add the git sha if we are doing and out-of-tree build. Instead, rely only on the version provided by the meson project.