### PR TITLE
build: nlohmann_json: Update from v3.11.2 to v3.12.0

### DIFF
--- a/subprojects/nlohmann_json.wrap
+++ b/subprojects/nlohmann_json.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = nlohmann_json-3.11.2
+directory = nlohmann_json-3.12.0
 lead_directory_missing = true
-source_url = https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
-source_filename = nlohmann_json-3.11.2.zip
-source_hash = e5c7a9f49a16814be27e4ed0ee900ecd0092bfb7dbfca65b5a421b774dccaaed
-wrapdb_version = 3.11.2-1
+
+source_url = https://github.com/nlohmann/json/releases/download/v3.12.0/include.zip
+source_filename = nlohmann_json-3.12.0.zip
+source_hash = b8cb0ef2dd7f57f18933997c9934bb1fa962594f701cd5a8d3c2c80541559372
 
 [provide]
 nlohmann_json = nlohmann_json_dep


### PR DESCRIPTION
This fixes a build error as reported in https://github.com/raspberrypi/libpisp/issues/57