### PR TITLE
helpers: Own the BackEnd and manage hardware lifecycle

### DIFF
--- a/src/examples/convert.cpp
+++ b/src/examples/convert.cpp
@@ -258,15 +258,11 @@ int main(int argc, char *argv[])
 		exit(0);
 	}
 
-	std::string media_dev = devices.Acquire();
-	if (media_dev.empty())
-	{
-		std::cerr << "Unable to acquire any pisp_be device!" << std::endl;
-		exit(-1);
-	}
+	libpisp::helpers::BackendDevice backend_device {};
+	std::cerr << "Acquired device " << backend_device.MediaDev() << std::endl;
 
-	libpisp::helpers::BackendDevice backend_device { media_dev };
-	std::cerr << "Acquired device " << media_dev << std::endl;
+	libpisp::BackEnd *be = backend_device.Get();
+	const libpisp::PiSPVariant &variant = backend_device.Variant();
 
 	auto in_file = parse_format(args["input-format"].as<std::string>());
 	if (!Formats.count(in_file.format))
@@ -282,24 +278,12 @@ int main(int argc, char *argv[])
 		exit(-1);
 	}
 
-	const std::vector<libpisp::PiSPVariant> &variants = libpisp::get_variants();
-	const media_device_info info = devices.DeviceInfo(media_dev);
-	auto variant = std::find_if(variants.begin(), variants.end(),
-								[&info](const auto &v) { return v.BackEndVersion() == info.hw_revision; });
-	if (variant == variants.end())
-	{
-		std::cerr << "Backend hardware cound not be identified: " << info.hw_revision << std::endl;
-		exit(-1);
-	}
-
-	libpisp::BackEnd be(libpisp::BackEnd::Config({}), *variant);
-
 	pisp_be_global_config global;
-	be.GetGlobal(global);
+	be->GetGlobal(global);
 	global.bayer_enables = 0;
 	global.rgb_enables = PISP_BE_RGB_ENABLE_INPUT + PISP_BE_RGB_ENABLE_OUTPUT0;
 
-	if (in_file.format == "RGBX8888" && !variant->BackendRGB32Supported(0))
+	if (in_file.format == "RGBX8888" && !variant.BackendRGB32Supported(0))
 	{
 		std::cerr << "Backend hardware does not support RGBX input" << std::endl;
 		exit(-1);
@@ -310,10 +294,10 @@ int main(int argc, char *argv[])
 	i.format = libpisp::get_pisp_image_format(in_file.format);
 	assert(i.format);
 	libpisp::compute_optimal_stride(i);
-	be.SetInputFormat(i);
+	be->SetInputFormat(i);
 
 	pisp_be_output_format_config o = {};
-	if (out_file.format == "RGBX8888" && !variant->BackendRGB32Supported(0))
+	if (out_file.format == "RGBX8888" && !variant.BackendRGB32Supported(0))
 	{
 		// Hack to generate RGBX even when BE_MINOR_VERSION < 1 using Resample
 		if (out_file.width < i.width)
@@ -330,7 +314,7 @@ int main(int argc, char *argv[])
 		csc.offsets[0] = 131072; // round to nearest after Resample, for 8-bit output
 		csc.offsets[1] = 131072;
 		csc.offsets[2] = 131072;
-		be.SetCsc(0, csc);
+		be->SetCsc(0, csc);
 		global.rgb_enables |= PISP_BE_RGB_ENABLE_CSC0;
 	}
 	else
@@ -341,7 +325,7 @@ int main(int argc, char *argv[])
 	}
 	assert(o.image.format);
 	libpisp::compute_optimal_stride(o.image, true);
-	be.SetOutputFormat(0, o);
+	be->SetOutputFormat(0, o);
 
 	if (!out_file.stride)
 		out_file.stride = o.image.stride;
@@ -349,27 +333,24 @@ int main(int argc, char *argv[])
 	if (in_file.format >= "U")
 	{
 		pisp_be_ccm_config csc;
-		be.InitialiseYcbcrInverse(csc, "jpeg");
-		be.SetCcm(csc);
+		be->InitialiseYcbcrInverse(csc, "jpeg");
+		be->SetCcm(csc);
 		global.rgb_enables |= PISP_BE_RGB_ENABLE_CCM;
 	}
 
 	if (out_file.format >= "U")
 	{
 		pisp_be_ccm_config csc;
-		be.InitialiseYcbcr(csc, "jpeg");
-		be.SetCsc(0, csc);
+		be->InitialiseYcbcr(csc, "jpeg");
+		be->SetCsc(0, csc);
 		global.rgb_enables |= PISP_BE_RGB_ENABLE_CSC0;
 	}
 
-	be.SetGlobal(global);
-	be.SetCrop(0, { 0, 0, i.width, i.height });
-	be.SetSmartResize(0, { o.image.width, o.image.height });
+	be->SetGlobal(global);
+	be->SetCrop(0, { 0, 0, i.width, i.height });
+	be->SetSmartResize(0, { o.image.width, o.image.height });
 
-	pisp_be_tiles_config config = {};
-	be.Prepare(&config);
-
-	backend_device.Setup(config);
+	backend_device.Prepare();
 	auto buffers = backend_device.GetBufferSlice();
 
 	std::string input_filename = args["input"].as<std::string>();

--- a/src/gst/gstpispconvert.cpp
+++ b/src/gst/gstpispconvert.cpp
@@ -358,7 +358,6 @@ static void gst_pisp_convert_init(GstPispConvert *self)
 	/* Initialize private data */
 	self->priv = new GstPispConvertPrivate();
 	self->priv->backend_device = nullptr;
-	self->priv->backend = nullptr;
 	self->priv->media_dev_path = nullptr;
 	self->priv->configured = FALSE;
 	self->priv->dmabuf_allocator = gst_dmabuf_allocator_new();
@@ -766,11 +765,13 @@ static void copy_pisp_to_buffer(const std::array<uint8_t *, 3> &mem, GstBuffer *
  */
 static gboolean gst_pisp_convert_configure(GstPispConvert *self)
 {
-	if (!self->priv->backend_device || !self->priv->backend)
+	if (!self->priv->backend_device)
 	{
 		GST_ERROR_OBJECT(self, "Backend not initialized");
 		return FALSE;
 	}
+
+	libpisp::BackEnd *backend = self->priv->backend_device->Get();
 
 	/* Check which outputs are enabled */
 	gboolean any_output = FALSE;
@@ -833,7 +834,7 @@ static gboolean gst_pisp_convert_configure(GstPispConvert *self)
 	try
 	{
 		pisp_be_global_config global;
-		self->priv->backend->GetGlobal(global);
+		backend->GetGlobal(global);
 		global.bayer_enables = 0;
 		global.rgb_enables = PISP_BE_RGB_ENABLE_INPUT;
 
@@ -849,7 +850,7 @@ static gboolean gst_pisp_convert_configure(GstPispConvert *self)
 		}
 		libpisp::compute_stride(input_cfg);
 		self->priv->in_hw_stride = input_cfg.stride;
-		self->priv->backend->SetInputFormat(input_cfg);
+		backend->SetInputFormat(input_cfg);
 
 		GST_INFO_OBJECT(self, "Input: %ux%u %s (stride: gst=%u hw=%u) colorspace %s", self->priv->in_width,
 						self->priv->in_height, self->priv->in_format, self->priv->in_stride, self->priv->in_hw_stride,
@@ -877,26 +878,26 @@ static gboolean gst_pisp_convert_configure(GstPispConvert *self)
 			}
 			libpisp::compute_optimal_stride(output_cfg[i].image, true);
 			self->priv->out_hw_stride[i] = output_cfg[i].image.stride;
-			self->priv->backend->SetOutputFormat(i, output_cfg[i]);
+			backend->SetOutputFormat(i, output_cfg[i]);
 
 			if ((g_str_equal(self->priv->out_format[i], "RGBX8888") ||
 				 g_str_equal(self->priv->out_format[i], "XRGB8888")) &&
-				!self->priv->variant->BackendRGB32Supported(0))
+				!self->priv->backend_device->Variant().BackendRGB32Supported(0))
 				GST_WARNING_OBJECT(self, "pisp_be HW does not support 32-bit RGB output, the image will be corrupt.");
 
 			if (!self->priv->out_colorspace[i])
 				self->priv->out_colorspace[i] = self->priv->in_colorspace;
 
-			global.rgb_enables |= configure_colour_conversion(self->priv->backend.get(), self->priv->in_format,
-															  self->priv->in_colorspace, self->priv->out_format[i],
-															  self->priv->out_colorspace[i], i);
+			global.rgb_enables |= configure_colour_conversion(backend, self->priv->in_format, self->priv->in_colorspace,
+															  self->priv->out_format[i], self->priv->out_colorspace[i],
+															  i);
 
 			GST_INFO_OBJECT(self, "Output%d: %ux%u %s (stride: gst=%u hw=%u) colorspace %s", i,
 							self->priv->out_width[i], self->priv->out_height[i], self->priv->out_format[i],
 							self->priv->out_stride[i], self->priv->out_hw_stride[i], self->priv->out_colorspace[i]);
 		}
 
-		self->priv->backend->SetGlobal(global);
+		backend->SetGlobal(global);
 
 		for (unsigned int i = 0; i < PISP_NUM_OUTPUTS; i++)
 		{
@@ -927,7 +928,7 @@ static gboolean gst_pisp_convert_configure(GstPispConvert *self)
 			/* Only call SetCrop if parameters changed */
 			if (memcmp(&crop, &self->priv->applied_crop[i], sizeof(crop)) != 0)
 			{
-				self->priv->backend->SetCrop(i, crop);
+				backend->SetCrop(i, crop);
 				self->priv->applied_crop[i] = crop;
 			}
 
@@ -936,15 +937,13 @@ static gboolean gst_pisp_convert_configure(GstPispConvert *self)
 														   (uint16_t)output_cfg[i].image.height };
 			if (memcmp(&smart_resize, &self->priv->applied_smart_resize[i], sizeof(smart_resize)) != 0)
 			{
-				self->priv->backend->SetSmartResize(i, smart_resize);
+				backend->SetSmartResize(i, smart_resize);
 				self->priv->applied_smart_resize[i] = smart_resize;
 			}
 		}
 
 		/* Prepare the hardware configuration */
-		pisp_be_tiles_config config = {};
-		self->priv->backend->Prepare(&config);
-		self->priv->backend_device->Setup(config, self->priv->output_buffer_count);
+		self->priv->backend_device->Prepare(self->priv->output_buffer_count);
 
 		self->priv->pisp_buffers = self->priv->backend_device->GetBuffers();
 		self->priv->buffer_slice_index = 0;
@@ -1197,17 +1196,7 @@ static gboolean gst_pisp_convert_start(GstPispConvert *self)
 
 	try
 	{
-		libpisp::helpers::MediaDevice devices;
-
-		std::string media_dev = devices.Acquire();
-		if (media_dev.empty())
-		{
-			GST_ERROR_OBJECT(self, "Unable to acquire any pisp_be device!");
-			return FALSE;
-		}
-
-		self->priv->media_dev_path = g_strdup(media_dev.c_str());
-		self->priv->backend_device = std::make_unique<libpisp::helpers::BackendDevice>(media_dev);
+		self->priv->backend_device = std::make_unique<libpisp::helpers::BackendDevice>();
 
 		if (!self->priv->backend_device->Valid())
 		{
@@ -1215,22 +1204,9 @@ static gboolean gst_pisp_convert_start(GstPispConvert *self)
 			return FALSE;
 		}
 
-		const std::vector<libpisp::PiSPVariant> &variants = libpisp::get_variants();
-		const media_device_info info = devices.DeviceInfo(media_dev);
+		self->priv->media_dev_path = g_strdup(self->priv->backend_device->MediaDev().c_str());
 
-		auto variant_it = std::find_if(variants.begin(), variants.end(),
-									   [&info](const auto &v) { return v.BackEndVersion() == info.hw_revision; });
-
-		if (variant_it == variants.end())
-		{
-			GST_ERROR_OBJECT(self, "Backend hardware could not be identified: %u", info.hw_revision);
-			return FALSE;
-		}
-
-		self->priv->variant = &(*variant_it);
-		self->priv->backend = std::make_unique<libpisp::BackEnd>(libpisp::BackEnd::Config({}), *variant_it);
-
-		GST_INFO_OBJECT(self, "Acquired device %s", media_dev.c_str());
+		GST_INFO_OBJECT(self, "Acquired device %s", self->priv->media_dev_path);
 	}
 	catch (const std::exception &e)
 	{
@@ -1272,7 +1248,6 @@ static gboolean gst_pisp_convert_stop(GstPispConvert *self)
 		self->priv->pending_segment = nullptr;
 	}
 
-	self->priv->backend.reset();
 	self->priv->backend_device.reset();
 
 	g_free(self->priv->media_dev_path);

--- a/src/gst/gstpispconvert.h
+++ b/src/gst/gstpispconvert.h
@@ -50,8 +50,6 @@ struct _GstPispConvertPrivate
 {
 	/* C++ objects */
 	std::unique_ptr<libpisp::helpers::BackendDevice> backend_device;
-	std::unique_ptr<libpisp::BackEnd> backend;
-	const libpisp::PiSPVariant *variant;
 
 	/* Device info */
 	char *media_dev_path;

--- a/src/helpers/backend_device.cpp
+++ b/src/helpers/backend_device.cpp
@@ -7,6 +7,7 @@
 
 #include "backend_device.hpp"
 
+#include <algorithm>
 #include <cstring>
 
 using namespace libpisp::helpers;
@@ -27,7 +28,11 @@ const Buffer &AsBuffer(const Buffer &b)
 
 BackendDevice::BackendDevice(const std::string &device) : valid_(true)
 {
-	nodes_ = MediaDevice().OpenV4l2Nodes(device);
+	media_dev_ = MediaDevice().Acquire(device);
+	if (media_dev_.empty())
+		throw std::runtime_error("Unable to acquire any pisp_be device!");
+
+	nodes_ = MediaDevice().OpenV4l2Nodes(media_dev_);
 	if (nodes_.empty())
 	{
 		valid_ = false;
@@ -37,6 +42,16 @@ BackendDevice::BackendDevice(const std::string &device) : valid_(true)
 	// Allocate a config buffer to persist.
 	nodes_.at("pispbe-config").AllocateBuffers(1);
 	nodes_.at("pispbe-config").StreamOn();
+
+	const std::vector<libpisp::PiSPVariant> &variants = libpisp::get_variants();
+	const media_device_info info = MediaDevice().DeviceInfo(media_dev_);
+	auto variant = std::find_if(variants.begin(), variants.end(),
+								[&info](const auto &v) { return v.BackEndVersion() == info.hw_revision; });
+	if (variant == variants.end())
+		throw std::runtime_error("Backend hardware could not be identified: " + std::to_string(info.hw_revision));
+
+	variant_ = *variant;
+	be_ = std::make_unique<libpisp::BackEnd>(libpisp::BackEnd::Config({}), variant_);
 }
 
 BackendDevice::~BackendDevice()
@@ -47,10 +62,13 @@ BackendDevice::~BackendDevice()
 		nodes_.at(n).StreamOff();
 }
 
-void BackendDevice::Setup(const pisp_be_tiles_config &config, unsigned int buffer_count, bool use_opaque_format)
+void BackendDevice::Prepare(unsigned int buffer_count, bool use_opaque_format)
 {
 	for (auto const &n : nodes_enabled_)
 		nodes_.at(n).StreamOff();
+
+	pisp_be_tiles_config config = {};
+	be_->Prepare(&config);
 
 	nodes_enabled_.clear();
 

--- a/src/helpers/backend_device.hpp
+++ b/src/helpers/backend_device.hpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_set>
 
@@ -14,16 +15,18 @@
 #include "media_device.hpp"
 #include "v4l2_device.hpp"
 
+#include "backend/backend.hpp"
+
 namespace libpisp::helpers
 {
 
 class BackendDevice
 {
 public:
-	BackendDevice(const std::string &device);
+	BackendDevice(const std::string &device = "");
 	~BackendDevice();
 
-	void Setup(const pisp_be_tiles_config &config, unsigned int buffer_count = 1, bool use_opaque_format = false);
+	void Prepare(unsigned int buffer_count = 1, bool use_opaque_format = false);
 
 	template <typename T>
 	int Run(const T &buffers);
@@ -38,6 +41,21 @@ public:
 		return nodes_.at(node);
 	}
 
+	std::string MediaDev() const
+	{
+		return media_dev_;
+	}
+
+	libpisp::BackEnd *Get()
+	{
+		return be_.get();
+	}
+
+	const libpisp::PiSPVariant &Variant() const
+	{
+		return variant_;
+	}
+
 	std::map<std::string, std::vector<BufferRef>> GetBuffers();
 	std::map<std::string, BufferRef> GetBufferSlice() const;
 	BufferRef ConfigBuffer()
@@ -50,6 +68,9 @@ private:
 	V4l2DevMap nodes_;
 	MediaDevice devices_;
 	std::unordered_set<std::string> nodes_enabled_;
+	std::string media_dev_;
+	std::unique_ptr<libpisp::BackEnd> be_;
+	libpisp::PiSPVariant variant_;
 };
 
 } // namespace libpisp::helpers


### PR DESCRIPTION
Rework BackendDevice to create and own a BackEnd instance internally. The constructor now acquires the media device, detects the hardware variant, and creates the BackEnd. A new Prepare() method replaces Setup() by calling BackEnd::Prepare() internally and configuring all V4L2 nodes from the generated config.

Access the Backend using a new Get() member, MediaDev() for the acquired device path, and Variant() for the detected hardware variant.

Update convert example and GStreamer plugin to use the simplified API.