### PR TITLE
backend: Add output image offset parameters

### DIFF
--- a/src/libpisp/backend/backend.cpp
+++ b/src/libpisp/backend/backend.cpp
@@ -410,15 +410,30 @@ void BackEnd::SetOutputFormat(unsigned int i, pisp_be_output_format_config const
 	PISP_ASSERT(i < variant_.BackEndNumBranches(0));
 	be_config_.output_format[i] = output_format;
 	be_config_.output_format[i].pad[0] = be_config_.output_format[i].pad[1] = be_config_.output_format[i].pad[2] = 0;
+	be_config_extra_.output_format[i] = { 0, 0 };
 	be_config_extra_.dirty_flags_rgb |= PISP_BE_RGB_ENABLE_OUTPUT(i);
 	// Should only need a retile if the transform has changed, othwise a finalise_tile will do.
 	retile_ = true;
+}
+
+void BackEnd::SetOutputFormat(unsigned int i, pisp_be_output_format_config const &output_format,
+							  pisp_be_output_format_extra const &output_extra)
+{
+	SetOutputFormat(i, output_format);
+	be_config_extra_.output_format[i] = output_extra;
 }
 
 void BackEnd::GetOutputFormat(unsigned int i, pisp_be_output_format_config &output_format) const
 {
 	PISP_ASSERT(i < variant_.BackEndNumBranches(0));
 	output_format = be_config_.output_format[i];
+}
+
+void BackEnd::GetOutputFormat(unsigned int i, pisp_be_output_format_config &output_format,
+							  pisp_be_output_format_extra &output_extra) const
+{
+	GetOutputFormat(i, output_format);
+	output_extra = be_config_extra_.output_format[i];
 }
 
 void BackEnd::SetSmartResize(unsigned int i, BackEnd::SmartResize const &smart_resize)

--- a/src/libpisp/backend/backend.hpp
+++ b/src/libpisp/backend/backend.hpp
@@ -136,7 +136,11 @@ public:
 	void SetCsc(unsigned int i, pisp_be_ccm_config const &csc);
 	void GetCsc(unsigned int i, pisp_be_ccm_config &csc) const;
 	void SetOutputFormat(unsigned int i, pisp_be_output_format_config const &output_format);
+	void SetOutputFormat(unsigned int i, pisp_be_output_format_config const &output_format,
+						 pisp_be_output_format_extra const &output_extra);
 	void GetOutputFormat(unsigned int i, pisp_be_output_format_config &output_format) const;
+	void GetOutputFormat(unsigned int i, pisp_be_output_format_config &output_format,
+						 pisp_be_output_format_extra &output_extra) const;
 	void SetResample(unsigned int i, pisp_be_resample_config const &resample,
 					 pisp_be_resample_extra const &resample_extra);
 	void GetResample(unsigned int i, pisp_be_resample_config &resample, pisp_be_resample_extra &resample_extra) const;
@@ -201,6 +205,7 @@ private:
 		pisp_be_downscale_extra downscale[PISP_BACK_END_NUM_OUTPUTS];
 		pisp_be_resample_extra resample[PISP_BACK_END_NUM_OUTPUTS];
 		pisp_be_crop_config crop[PISP_BACK_END_NUM_OUTPUTS];
+		pisp_be_output_format_extra output_format[PISP_BACK_END_NUM_OUTPUTS];
 		uint32_t dirty_flags_bayer; //these use pisp_be_bayer_enable
 		uint32_t dirty_flags_rgb; //use pisp_be_rgb_enable
 		uint32_t dirty_flags_extra; //these use pisp_be_dirty_t

--- a/src/libpisp/backend/backend_prepare.cpp
+++ b/src/libpisp/backend/backend_prepare.cpp
@@ -947,7 +947,9 @@ void BackEnd::finaliseTiling()
 			if (be_config_.output_format[j].transform & PISP_BE_TRANSFORM_VFLIP)
 				t.output_offset_y[j] = be_config_.output_format[j].image.height - output_offset_y_unflipped - 1;
 
-			compute_addr_offset(be_config_.output_format[j].image, t.output_offset_x[j], t.output_offset_y[j],
+			compute_addr_offset(be_config_.output_format[j].image,
+								t.output_offset_x[j] + be_config_extra_.output_format[j].offset_x,
+								t.output_offset_y[j] + be_config_extra_.output_format[j].offset_y,
 								&t.output_addr_offset[j], &t.output_addr_offset2[j]);
 
 			PISP_LOG(debug, "Branch " << j << " output offsets " << t.output_offset_x[j] << "," << t.output_offset_y[j]

--- a/src/libpisp/backend/pisp_be_config.h
+++ b/src/libpisp/backend/pisp_be_config.h
@@ -733,6 +733,19 @@ struct pisp_be_output_format_config
 } __attribute__((packed));
 
 /**
+ * struct pisp_be_output_format_extra - PiSP Back End output format extra config
+ *
+ * Output format extra configuration
+ *
+ * @offset_x:	Horizontal offset of the output window
+ * @offset_y:	Vertical offset of the output window
+ */
+struct pisp_be_output_format_extra {
+	__u16 offset_x;
+	__u16 offset_y;
+} __attribute__((packed));
+
+/**
  * struct pisp_be_output_buffer_config - PiSP Back End Output buffer
  * @addr:		Output buffer address
  */


### PR DESCRIPTION
The output images can now be offset into a "window" within a larger image buffer.

We need only supply two extra x, y offsets to the output format configurations, and apply them when calculating buffer addresses.