### PR TITLE
backend: Allow offsets to be specified as pixels or bytes

### DIFF
--- a/src/libpisp/backend/backend.cpp
+++ b/src/libpisp/backend/backend.cpp
@@ -410,7 +410,7 @@ void BackEnd::SetOutputFormat(unsigned int i, pisp_be_output_format_config const
 	PISP_ASSERT(i < variant_.BackEndNumBranches(0));
 	be_config_.output_format[i] = output_format;
 	be_config_.output_format[i].pad[0] = be_config_.output_format[i].pad[1] = be_config_.output_format[i].pad[2] = 0;
-	be_config_extra_.output_format[i] = { 0, 0 };
+	be_config_extra_.output_format[i] = { 0, 0, { 0, 0 } };
 	be_config_extra_.dirty_flags_rgb |= PISP_BE_RGB_ENABLE_OUTPUT(i);
 	// Should only need a retile if the transform has changed, othwise a finalise_tile will do.
 	retile_ = true;
@@ -421,6 +421,13 @@ void BackEnd::SetOutputFormat(unsigned int i, pisp_be_output_format_config const
 {
 	SetOutputFormat(i, output_format);
 	be_config_extra_.output_format[i] = output_extra;
+}
+
+void BackEnd::SetOutputFormatExtra(unsigned int i, pisp_be_output_format_extra const &output_extra)
+{
+	be_config_extra_.output_format[i] = output_extra;
+	be_config_extra_.dirty_flags_rgb |= PISP_BE_RGB_ENABLE_OUTPUT(i);
+	finalise_tiling_ = true;
 }
 
 void BackEnd::GetOutputFormat(unsigned int i, pisp_be_output_format_config &output_format) const

--- a/src/libpisp/backend/backend.hpp
+++ b/src/libpisp/backend/backend.hpp
@@ -138,6 +138,7 @@ public:
 	void SetOutputFormat(unsigned int i, pisp_be_output_format_config const &output_format);
 	void SetOutputFormat(unsigned int i, pisp_be_output_format_config const &output_format,
 						 pisp_be_output_format_extra const &output_extra);
+	void SetOutputFormatExtra(unsigned int i, pisp_be_output_format_extra const &output_extra);
 	void GetOutputFormat(unsigned int i, pisp_be_output_format_config &output_format) const;
 	void GetOutputFormat(unsigned int i, pisp_be_output_format_config &output_format,
 						 pisp_be_output_format_extra &output_extra) const;

--- a/src/libpisp/backend/backend_prepare.cpp
+++ b/src/libpisp/backend/backend_prepare.cpp
@@ -951,6 +951,8 @@ void BackEnd::finaliseTiling()
 								t.output_offset_x[j] + be_config_extra_.output_format[j].offset_x,
 								t.output_offset_y[j] + be_config_extra_.output_format[j].offset_y,
 								&t.output_addr_offset[j], &t.output_addr_offset2[j]);
+			t.output_addr_offset[j] += be_config_extra_.output_format[j].offset_bytes[0];
+			t.output_addr_offset2[j] += be_config_extra_.output_format[j].offset_bytes[1];
 
 			PISP_LOG(debug, "Branch " << j << " output offsets " << t.output_offset_x[j] << "," << t.output_offset_y[j]
 									  << " address offsets " << t.output_addr_offset[j] << " and "

--- a/src/libpisp/backend/pisp_be_config.h
+++ b/src/libpisp/backend/pisp_be_config.h
@@ -739,10 +739,15 @@ struct pisp_be_output_format_config
  *
  * @offset_x:	Horizontal offset of the output window
  * @offset_y:	Vertical offset of the output window
+ * @offset_bytes:	Offset of the output window in bytes for up to two output planes
+ *
+ * Applications will normally pass either offset_x/y or offset_bytes, leaving the
+ * ones they aren't using at zero.
  */
 struct pisp_be_output_format_extra {
 	__u16 offset_x;
 	__u16 offset_y;
+	__u32 offset_bytes[2];
 } __attribute__((packed));
 
 /**


### PR DESCRIPTION
Applications can pass both an (x, y) pair or a number of bytes (typically they will use only one of these, setting the other to zero).